### PR TITLE
🍱 ✨ update CI workflow to generate HTML coverage report and publish t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, feature/*  ]
+    branches: [ main, feature/* ]
 
 jobs:
   build:
@@ -55,14 +55,38 @@ jobs:
 
     # Generate and upload coverage report as artifact
     - name: Generate HTML coverage report
-      run: go tool cover -html=coverage.txt -o coverage.html
+      run: |
+        mkdir -p coverage
+        go tool cover -html=coverage.txt -o coverage/index.html
+        echo '<meta http-equiv="refresh" content="0; url=./index.html" />' > coverage/index.md
       
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
-        path: coverage.html
+        path: coverage/
         retention-days: 7
 
     - name: Build
       run: go build -v ./...
+
+  # New job to publish coverage report to GitHub Pages
+  publish-coverage:
+    needs: build
+    if: github.ref == 'refs/heads/main'  # Only run on main branch
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Download coverage artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage
+    
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./coverage
+        destination_dir: coverage
+        keep_files: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Go-Schema is a lightweight data validation library for Go, inspired by [Cerberus from Python](https://github.com/pyeve/cerberus). It allows for easy schema definition and provides clear and detailed validation errors.
 
+[![Coverage Report](https://img.shields.io/badge/coverage-report-blue)](https://josesalasdev.github.io/go-schema/coverage/)
+
 ## Features
 
 - **Simple yet Powerful Validation**: Define clear and concise schemas for structured data validation.


### PR DESCRIPTION
This pull request introduces improvements to the CI workflow for generating and publishing code coverage reports. The changes include restructuring the coverage report generation process and adding a new job to publish the report to GitHub Pages.

Improvements to coverage report generation:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL58-R92): Modified the coverage report generation to create a directory for the report and added a meta refresh file for easier navigation.

Publishing coverage report to GitHub Pages:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL58-R92): Added a new job to publish the coverage report to GitHub Pages, which runs only on the main branch. This job downloads the coverage artifact and deploys it using the `peaceiris/actions-gh-pages` action.