### PR TITLE
♻️ 🔧 update CI workflow to add permissions for contents and pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main, feature/* ]
 
+# Añadir esta sección de permisos
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes an important update to the GitHub Actions workflow configuration in the `.github/workflows/ci.yml` file. The change adds a permissions section to specify the required permissions for the workflow.

Changes to GitHub Actions workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R13): Added a permissions section to grant `contents: write` and `pages: write` permissions for the workflow.